### PR TITLE
Add maxPaths constant

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 )
 
+// maxPaths limits the number of candidate paths explored when searching the graph.
+const maxPaths = 100
+
 type Room struct {
 	Name  string
 	X, Y  int
@@ -250,7 +253,7 @@ func bestDisjointPaths(all [][]*Room, ants int) [][]*Room {
 // findPaths gathers disjoint paths and selects the prefix that minimises the
 // number of turns required to send all ants across the colony.
 func findPaths(g *Graph) [][]*Room {
-	all := allPaths(g, 100)
+	all := allPaths(g, maxPaths)
 	sort.SliceStable(all, func(i, j int) bool {
 		li, lj := len(all[i]), len(all[j])
 		if li == lj {


### PR DESCRIPTION
## Summary
- limit all path enumeration using new `maxPaths` constant
- use `maxPaths` in `findPaths`
- explain constant purpose in a comment

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884d865a9488333a4d5df739bbf0ce5